### PR TITLE
Support some options

### DIFF
--- a/NotifyPropertyChangedGenerator.Annotations.Nuget/Diagnostic.nuspec
+++ b/NotifyPropertyChangedGenerator.Annotations.Nuget/Diagnostic.nuspec
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>NotifyPropertyChangedGenerator.Annotations</id>
+        <version>1.0.0.0</version>
+        <title>NotifyPropertyChangedGenerator.Annotations</title>
+        <authors>neuecc</authors>
+        <projectUrl>https://github.com/neuecc/NotifyPropertyChangedGenerator</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Roslyn Analyzer/Generator for avoid boring boilerplate INotifyPropertyChanged implementation with an annotation library.</description>
+        <releaseNotes>Initial release.</releaseNotes>
+        <tags>analyzers INotifyPropertyChanged MVVM</tags>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System" targetFramework="" />
+        </frameworkAssemblies>
+    </metadata>
+    <files>
+        <file src="NotifyPropertyChangedGenerator.dll" target="tools\analyzers\" />
+        <file src="NotifyPropertyChangedGenerator.Annotations.dll" target="lib\" />
+        <file src="NotifyPropertyChangedGenerator.Annotations.pdb" target="lib\" />
+        <file src="NotifyPropertyChangedGenerator.Annotations.xml" target="lib\" />
+        <file src="tools\*.ps1" target="tools\" />
+    </files>
+</package>

--- a/NotifyPropertyChangedGenerator.Annotations.Nuget/NotifyPropertyChangedGenerator.Annotations.Nuget.csproj
+++ b/NotifyPropertyChangedGenerator.Annotations.Nuget/NotifyPropertyChangedGenerator.Annotations.Nuget.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{365D9B23-94DD-4853-87DB-82F2D45C7F90}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NotifyPropertyChangedGenerator.Annotations.Nuget</RootNamespace>
+    <AssemblyName>NotifyPropertyChangedGenerator.Annotations.Nuget</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Diagnostic.nuspec">
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+    <None Include="tools\install.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="tools\uninstall.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NotifyPropertyChangedGenerator.Annotations\NotifyPropertyChangedGenerator.Annotations.csproj">
+      <Project>{75b14c0b-0fe9-4a36-b4e6-be7c3508497e}</Project>
+      <Name>NotifyPropertyChangedGenerator.Annotations</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NotifyPropertyChangedGenerator\NotifyPropertyChangedGenerator\NotifyPropertyChangedGenerator.csproj">
+      <Project>{d98b83ea-3dc3-4379-9b7b-5ee033ba9c2b}</Project>
+      <Name>NotifyPropertyChangedGenerator</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>"$(SolutionDir)\packages\NuGet.CommandLine.2.8.5\tools\NuGet.exe" pack Diagnostic.nuspec -NoPackageAnalysis -OutputDirectory .</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NotifyPropertyChangedGenerator.Annotations.Nuget/Properties/AssemblyInfo.cs
+++ b/NotifyPropertyChangedGenerator.Annotations.Nuget/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("NotifyPropertyChangedGenerator.Annotations.Nuget")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NotifyPropertyChangedGenerator.Annotations.Nuget")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
+// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// 次の GUID は、このプロジェクトが COM に公開される場合の、typelib の ID です
+[assembly: Guid("365d9b23-94dd-4853-87db-82f2d45c7f90")]
+
+// アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
+// 既定値にすることができます:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NotifyPropertyChangedGenerator.Annotations.Nuget/packages.config
+++ b/NotifyPropertyChangedGenerator.Annotations.Nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NuGet.CommandLine" version="2.8.5" targetFramework="net45" userInstalled="true" />
+</packages>

--- a/NotifyPropertyChangedGenerator.Annotations.Nuget/tools/install.ps1
+++ b/NotifyPropertyChangedGenerator.Annotations.Nuget/tools/install.ps1
@@ -1,0 +1,24 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+$analyzersPath = join-path $toolsPath "analyzers"
+
+# Install the language agnostic analyzers.
+foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+{
+    if($project.Object.AnalyzerReferences)
+    {
+        $project.Object.AnalyzerReferences.Add($analyzerFilePath.FullName)
+    }
+}
+
+# Install language specific analyzers.
+# $project.Type gives the language name like (C# or VB.NET)
+$languageAnalyzersPath = join-path $analyzersPath $project.Type
+
+foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+{
+    if($project.Object.AnalyzerReferences)
+    {
+        $project.Object.AnalyzerReferences.Add($analyzerFilePath.FullName)
+    }
+}

--- a/NotifyPropertyChangedGenerator.Annotations.Nuget/tools/uninstall.ps1
+++ b/NotifyPropertyChangedGenerator.Annotations.Nuget/tools/uninstall.ps1
@@ -1,0 +1,24 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+# Uninstall the language agnostic analyzers.
+$analyzersPath = join-path $toolsPath "analyzers"
+
+foreach ($analyzerFilePath in Get-ChildItem $analyzersPath -Filter *.dll)
+{
+    if($project.Object.AnalyzerReferences)
+    {
+        $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+    }
+}
+
+# Uninstall language specific analyzers.
+# $project.Type gives the language name like (C# or VB.NET)
+$languageAnalyzersPath = join-path $analyzersPath $project.Type
+
+foreach ($analyzerFilePath in Get-ChildItem $languageAnalyzersPath -Filter *.dll)
+{
+    if($project.Object.AnalyzerReferences)
+    {
+        $project.Object.AnalyzerReferences.Remove($analyzerFilePath.FullName)
+    }
+}

--- a/NotifyPropertyChangedGenerator.Annotations/CompareMethod.cs
+++ b/NotifyPropertyChangedGenerator.Annotations/CompareMethod.cs
@@ -1,0 +1,29 @@
+﻿namespace NotifyPropertyChangedGenerator.Annotations
+{
+    /// <summary>
+    /// Compare method in the generated SetProperty method.
+    /// </summary>
+    public enum CompareMethod
+    {
+        /*
+           - None: raises `PropertyChanged` at any time when the property set
+    - ReferenceEquals: 
+    - EqualityComparer: uses `EqualityComparer<T>.Default.Equals` to compare
+    old and new values
+    */
+        /// <summary>
+        /// Raises `PropertyChanged` at any time when the property set.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Uses <see cref="object.ReferenceEquals(object, object)"/> to compare old and new values.
+        /// </summary>
+        ReferenceEquals,
+
+        /// <summary>
+        /// Uses <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/> to compare old and new values.
+        /// </summary>
+        EqualityComparer,
+    }
+}

--- a/NotifyPropertyChangedGenerator.Annotations/NamingConvention.cs
+++ b/NotifyPropertyChangedGenerator.Annotations/NamingConvention.cs
@@ -1,0 +1,23 @@
+﻿namespace NotifyPropertyChangedGenerator.Annotations
+{
+    /// <summary>
+    /// Naming convention of the generated fields.
+    /// </summary>
+    public enum NamingConvention
+    {
+        /// <summary>
+        /// Uses lowerCamelCase of the original property for the generated field name.
+        /// </summary>
+        Plain,
+
+        /// <summary>
+        /// Uses "_" + [Plain name].
+        /// </summary>
+        LeadingUnderscore,
+
+        /// <summary>
+        /// Uses [Plain name] + "_".
+        /// </summary>
+        TrailingUnderscore,
+    }
+}

--- a/NotifyPropertyChangedGenerator.Annotations/NotifyAttribute.cs
+++ b/NotifyPropertyChangedGenerator.Annotations/NotifyAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace NotifyPropertyChangedGenerator.Annotations
+{
+    /// <summary>
+    /// Annotates a property or all of properties in a class as included to the code generation for the NotifyPropertyChanged.
+    /// </summary>
+    [Conditional("NEVER_USED_AT_RUNTIME")]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class NotifyAttribute : Attribute
+    {
+        /// <summary>
+        /// No option.
+        /// </summary>
+        public NotifyAttribute() { }
+
+        /// <summary>
+        /// Specify options as string.
+        /// </summary>
+        /// <param name="namingConvention"></param>
+        /// <param name="compareMethod"></param>
+        public NotifyAttribute(string namingConvention = null, string compareMethod = null) { }
+
+        /// <summary>
+        /// Specify options as enum.
+        /// </summary>
+        /// <param name="namingConvention"></param>
+        /// <param name="compareMethod"></param>
+        public NotifyAttribute(NamingConvention namingConvention = default(NamingConvention), CompareMethod compareMethod = default(CompareMethod)) { }
+    }
+
+    /// <summary>
+    /// Annotates a property as exluded from the code generation for the NotifyPropertyChanged.
+    /// </summary>
+    [Conditional("NEVER_USED_AT_RUNTIME")]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class NonNotifyAttribute : Attribute
+    {
+
+    }
+}

--- a/NotifyPropertyChangedGenerator.Annotations/NotifyPropertyChangedGenerator.Annotations.csproj
+++ b/NotifyPropertyChangedGenerator.Annotations/NotifyPropertyChangedGenerator.Annotations.csproj
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{75B14C0B-0FE9-4A36-B4E6-BE7C3508497E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NotifyPropertyChangedGenerator.Annotations</RootNamespace>
+    <AssemblyName>NotifyPropertyChangedGenerator.Annotations</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\NotifyPropertyChangedGenerator.Annotations.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\NotifyPropertyChangedGenerator.Annotations.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CompareMethod.cs" />
+    <Compile Include="NamingConvention.cs" />
+    <Compile Include="NotifyAttribute.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NotifyPropertyChangedGenerator.Annotations/Properties/AssemblyInfo.cs
+++ b/NotifyPropertyChangedGenerator.Annotations/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットをとおして制御されます。
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("NotifyPropertyChangedGenerator.Annotations")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NotifyPropertyChangedGenerator.Annotations")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから 
+// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// 次の GUID は、このプロジェクトが COM に公開される場合の、typelib の ID です
+[assembly: Guid("75b14c0b-0fe9-4a36-b4e6-be7c3508497e")]
+
+// アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// すべての値を指定するか、下のように '*' を使ってビルドおよびリビジョン番号を 
+// 既定値にすることができます:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NotifyPropertyChangedGenerator.sln
+++ b/NotifyPropertyChangedGenerator.sln
@@ -14,6 +14,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Root", "Root", "{A1B7D21B-1
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotifyPropertyChangedGenerator.Annotations", "NotifyPropertyChangedGenerator.Annotations\NotifyPropertyChangedGenerator.Annotations.csproj", "{75B14C0B-0FE9-4A36-B4E6-BE7C3508497E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NotifyPropertyChangedGenerator.Annotations.Nuget", "NotifyPropertyChangedGenerator.Annotations.Nuget\NotifyPropertyChangedGenerator.Annotations.Nuget.csproj", "{365D9B23-94DD-4853-87DB-82F2D45C7F90}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +36,14 @@ Global
 		{6C7EBA08-9DA2-4F57-A136-DAA7B0103993}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C7EBA08-9DA2-4F57-A136-DAA7B0103993}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C7EBA08-9DA2-4F57-A136-DAA7B0103993}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75B14C0B-0FE9-4A36-B4E6-BE7C3508497E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75B14C0B-0FE9-4A36-B4E6-BE7C3508497E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75B14C0B-0FE9-4A36-B4E6-BE7C3508497E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75B14C0B-0FE9-4A36-B4E6-BE7C3508497E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{365D9B23-94DD-4853-87DB-82F2D45C7F90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{365D9B23-94DD-4853-87DB-82F2D45C7F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{365D9B23-94DD-4853-87DB-82F2D45C7F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{365D9B23-94DD-4853-87DB-82F2D45C7F90}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator.Test/NotifyPropertyChangedGeneratorCodeFixVerifier.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator.Test/NotifyPropertyChangedGeneratorCodeFixVerifier.cs
@@ -16,16 +16,27 @@ namespace NotifyPropertyChangedGenerator.Test
             Id = NotifyPropertyChangedGeneratorDiagnosticAnalyzer.DiagnosticId,
             Message = String.Format("Notify property is not generated yet."),
             Severity = DiagnosticSeverity.Error,
-            Locations = new[] { new DiagnosticResultLocation("Test0.cs", 16, 1) }
+            Locations = new[] { new DiagnosticResultLocation("Test0.cs", 3, 1) }
         };
 
-        const string Attr = @"using System;
+        const string Usings = @"using System;
 using System.ComponentModel;
+";
+        const string Attr = @"
+
+internal enum NamingConvention
+{
+    Plain,
+    LeadingUnderscore,
+    TrailingUnderscore,
+}
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class NotifyAttribute : Attribute
 {
-
+    public NotifyAttribute() { }
+    public NotifyAttribute(string namingConvention = null) { }
+    public NotifyAttribute(NamingConvention namingConvention = default(NamingConvention)) { }
 }
 
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
@@ -49,7 +60,7 @@ internal sealed class NonNotifyAttribute : Attribute
         [TestMethod]
         public void SuccessForPropertyDecr()
         {
-            VerifyCSharpDiagnostic(Attr + @"public class MyClass : INotifyPropertyChanged
+            VerifyCSharpDiagnostic(Usings + @"public class MyClass : INotifyPropertyChanged
 {
     [Notify]
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -86,13 +97,13 @@ internal sealed class NonNotifyAttribute : Attribute
     }
 
     #endregion
-}");
+}" + Attr);
         }
 
         [TestMethod]
         public void SuccessForClassDecr()
         {
-            VerifyCSharpDiagnostic(Attr + @"[Notify]
+            VerifyCSharpDiagnostic(Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -128,13 +139,13 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}");
+}" + Attr);
         }
 
         [TestMethod]
         public void DoesNotHaveInterface()
         {
-            var source = Attr + @"public class MyClass
+            var source = Usings + @"public class MyClass
 {
     [Notify]
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -171,10 +182,10 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}";
+}" + Attr;
 
             VerifyCSharpDiagnostic(source, Expected);
-            VerifyCSharpFix(source, Attr + @"public class MyClass : INotifyPropertyChanged
+            VerifyCSharpFix(source, Usings + @"public class MyClass : INotifyPropertyChanged
 {
     [Notify]
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -211,14 +222,14 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}");
+}" + Attr);
 
         }
 
         [TestMethod]
         public void StandardPattern()
         {
-            var source = Attr + @"public class MyClass
+            var source = Usings + @"public class MyClass
 {
     [Notify]
     public int MyProperty { get; set; }
@@ -233,10 +244,10 @@ public class MyClass : INotifyPropertyChanged
     public void Method()
     {
     }
-}";
+}" + Attr;
 
             VerifyCSharpDiagnostic(source, Expected);
-            VerifyCSharpFix(source, Attr + @"public class MyClass : INotifyPropertyChanged
+            VerifyCSharpFix(source, Usings + @"public class MyClass : INotifyPropertyChanged
 {
     [Notify]
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -271,13 +282,13 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}");
+}" + Attr);
         }
 
         [TestMethod]
         public void StandardPatternClass()
         {
-            var source = Attr + @"[Notify]
+            var source = Usings + @"[Notify]
 public class MyClass
 {
     public int MyProperty { get; set; }
@@ -291,10 +302,10 @@ public class MyClass
     public void Method()
     {
     }
-}";
+}" + Attr;
 
             VerifyCSharpDiagnostic(source, Expected);
-            VerifyCSharpFix(source, Attr + @"[Notify]
+            VerifyCSharpFix(source, Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -328,13 +339,13 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}");
+}" + Attr);
         }
 
         [TestMethod]
         public void AddNewProperty()
         {
-            var source = Attr + @"[Notify]
+            var source = Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -373,10 +384,10 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}";
+}" + Attr;
 
             VerifyCSharpDiagnostic(source, Expected);
-            VerifyCSharpFix(source, Attr + @"[Notify]
+            VerifyCSharpFix(source, Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -417,13 +428,13 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}");
+}" + Attr);
         }
 
         [TestMethod]
         public void HiddenRegion()
         {
-            var source = Attr + @"[Notify]
+            var source = Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -458,7 +469,7 @@ public class MyClass : INotifyPropertyChanged
             PropertyChanged?.Invoke(this, ev);
         }
     }
-}";
+}" + Attr;
 
             VerifyCSharpDiagnostic(source, Expected);
         }
@@ -466,7 +477,7 @@ public class MyClass : INotifyPropertyChanged
         [TestMethod]
         public void BrokenRegion()
         {
-            var source = Attr + @"[Notify]
+            var source = Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -505,10 +516,10 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}";
+}" + Attr;
 
             VerifyCSharpDiagnostic(source, Expected);
-            VerifyCSharpFix(source, Attr + @"[Notify]
+            VerifyCSharpFix(source, Usings + @"[Notify]
 public class MyClass : INotifyPropertyChanged
 {
     public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
@@ -549,7 +560,78 @@ public class MyClass : INotifyPropertyChanged
     }
 
     #endregion
-}");
+}" + Attr);
+        }
+
+        [TestMethod]
+        public void NamingConvention()
+        {
+            var source = Usings + @"public class MyClass
+{
+    [Notify]
+    public int MyProperty { get; set; }
+    [Notify(""LeadingUnderscore"")]
+    public int MyProperty1 { get; set; }
+    [NotifyAttribute(""TrailingUnderscore"")]
+    public int MyProperty2 { get; set; }
+    [Notify(NamingConvention.LeadingUnderscore)]
+    public int MyProperty3 { get; set; }
+
+    public MyClass()
+    {
+
+    }
+
+    public void Method()
+    {
+    }
+}" + Attr;
+
+            VerifyCSharpDiagnostic(source, Expected);
+            VerifyCSharpFix(source, Usings + @"public class MyClass : INotifyPropertyChanged
+{
+    [Notify]
+    public int MyProperty { get { return myProperty; } set { SetProperty(ref myProperty, value, myPropertyPropertyChangedEventArgs); } }
+    [Notify(""LeadingUnderscore"")]
+    public int MyProperty1 { get { return _myProperty1; } set { SetProperty(ref _myProperty1, value, _myProperty1PropertyChangedEventArgs); } }
+    [NotifyAttribute(""TrailingUnderscore"")]
+    public int MyProperty2 { get { return myProperty2_; } set { SetProperty(ref myProperty2_, value, myProperty2_PropertyChangedEventArgs); } }
+    [Notify(NamingConvention.LeadingUnderscore)]
+    public int MyProperty3 { get { return _myProperty3; } set { SetProperty(ref _myProperty3, value, _myProperty3PropertyChangedEventArgs); } }
+
+    public MyClass()
+    {
+
+    }
+
+    public void Method()
+    {
+    }
+
+    #region NotifyPropertyChangedGenerator
+
+    public event PropertyChangedEventHandler PropertyChanged;
+
+    private int myProperty;
+    private static readonly PropertyChangedEventArgs myPropertyPropertyChangedEventArgs = new PropertyChangedEventArgs(nameof(MyProperty));
+    private int _myProperty1;
+    private static readonly PropertyChangedEventArgs _myProperty1PropertyChangedEventArgs = new PropertyChangedEventArgs(nameof(MyProperty1));
+    private int myProperty2_;
+    private static readonly PropertyChangedEventArgs myProperty2_PropertyChangedEventArgs = new PropertyChangedEventArgs(nameof(MyProperty2));
+    private int _myProperty3;
+    private static readonly PropertyChangedEventArgs _myProperty3PropertyChangedEventArgs = new PropertyChangedEventArgs(nameof(MyProperty3));
+
+    private void SetProperty<T>(ref T field, T value, PropertyChangedEventArgs ev)
+    {
+        if (!System.Collections.Generic.EqualityComparer<T>.Default.Equals(field, value))
+        {
+            field = value;
+            PropertyChanged?.Invoke(this, ev);
+        }
+    }
+
+    #endregion
+}" + Attr);
         }
     }
 }

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/CompareMethod.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/CompareMethod.cs
@@ -1,0 +1,9 @@
+﻿namespace NotifyPropertyChangedGenerator
+{
+    internal enum CompareMethod
+    {
+        None,
+        ReferenceEquals,
+        EqualityComparer,
+    }
+}

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/DeclarationSyntaxExtensions.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/DeclarationSyntaxExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace NotifyPropertyChangedGenerator
+{
+    internal static class DeclarationSyntaxExtensions
+    {
+        public static AttributeSyntax GetNotifyAttribute(this PropertyDeclarationSyntax p) => p.AttributeLists.GetAttribute("Notify");
+        public static AttributeSyntax GetNotifyAttribute(this ClassDeclarationSyntax p) => p.AttributeLists.GetAttribute("Notify");
+
+        public static AttributeSyntax GetNonNotifyAttribute(this PropertyDeclarationSyntax p) => p.AttributeLists.GetAttribute("NonNotify");
+        public static AttributeSyntax GetNonNotifyAttribute(this ClassDeclarationSyntax p) => p.AttributeLists.GetAttribute("NonNotify");
+
+        public static AttributeSyntax GetAttribute(this SyntaxList<AttributeListSyntax> attributes, string attributeName)
+            => attributes
+                .SelectMany(a => a.Attributes)
+                .FirstOrDefault(a =>
+                {
+                    var name = a.Name.ToString();
+                    return name == attributeName || name == attributeName + "Attribute";
+                });
+    }
+}

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/DeclarationSyntaxExtensions.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/DeclarationSyntaxExtensions.cs
@@ -7,10 +7,10 @@ namespace NotifyPropertyChangedGenerator
     internal static class DeclarationSyntaxExtensions
     {
         public static AttributeSyntax GetNotifyAttribute(this PropertyDeclarationSyntax p) => p.AttributeLists.GetAttribute("Notify");
-        public static AttributeSyntax GetNotifyAttribute(this ClassDeclarationSyntax p) => p.AttributeLists.GetAttribute("Notify");
+        public static AttributeSyntax GetNotifyAttribute(this ClassDeclarationSyntax c) => c.AttributeLists.GetAttribute("Notify");
 
         public static AttributeSyntax GetNonNotifyAttribute(this PropertyDeclarationSyntax p) => p.AttributeLists.GetAttribute("NonNotify");
-        public static AttributeSyntax GetNonNotifyAttribute(this ClassDeclarationSyntax p) => p.AttributeLists.GetAttribute("NonNotify");
+        public static AttributeSyntax GetNonNotifyAttribute(this ClassDeclarationSyntax c) => c.AttributeLists.GetAttribute("NonNotify");
 
         public static AttributeSyntax GetAttribute(this SyntaxList<AttributeListSyntax> attributes, string attributeName)
             => attributes
@@ -20,5 +20,17 @@ namespace NotifyPropertyChangedGenerator
                     var name = a.Name.ToString();
                     return name == attributeName || name == attributeName + "Attribute";
                 });
+
+        public static CompareMethod GetCompareMethod(this ClassDeclarationSyntax c)
+        {
+            var a = c.GetNotifyAttribute();
+            if (a == null) return CompareMethod.EqualityComparer;
+
+            var s = a.ToString();
+            return
+                s.Contains(nameof(CompareMethod.None)) ? CompareMethod.None :
+                s.Contains(nameof(CompareMethod.ReferenceEquals)) ? CompareMethod.ReferenceEquals :
+                CompareMethod.EqualityComparer;
+        }
     }
 }

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NamingConvention.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NamingConvention.cs
@@ -1,0 +1,11 @@
+﻿namespace NotifyPropertyChangedGenerator
+{
+    internal enum NamingConvention
+    {
+        Plain,
+
+        LeadingUnderscore,
+
+        TrailingUnderscore,
+    }
+}

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyAttribute.cs.pp
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyAttribute.cs.pp
@@ -9,7 +9,8 @@ namespace $rootnamespace$
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     internal sealed class NotifyAttribute : Attribute
     {
-
+        public NotifyAttribute() { }
+        public NotifyAttribute(string namingConvention = null, string compareMethod = null) { }
     }
 
     [Conditional("NEVER_USED_AT_RUNTIME")]

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyAttribute.cs.pp
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyAttribute.cs.pp
@@ -1,15 +1,18 @@
 ﻿// used from NotifyPropertyChangedGenerator
 
 using System;
+using System.Diagnostics;
 
 namespace $rootnamespace$
 {
+    [Conditional("NEVER_USED_AT_RUNTIME")]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     internal sealed class NotifyAttribute : Attribute
     {
 
     }
 
+    [Conditional("NEVER_USED_AT_RUNTIME")]
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
     internal sealed class NonNotifyAttribute : Attribute
     {

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator.csproj
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator.csproj
@@ -32,9 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="DeclarationSyntaxExtensions.cs" />
+    <Compile Include="NamingConvention.cs" />
     <Compile Include="NotifyPropertyChangedGeneratorCodeFixProvider.cs" />
     <Compile Include="NotifyPropertyChangedGeneratorDiagnosticAnalyzer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Property.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator.csproj
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator.csproj
@@ -32,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="CompareMethod.cs" />
     <Compile Include="DeclarationSyntaxExtensions.cs" />
     <Compile Include="NamingConvention.cs" />
     <Compile Include="NotifyPropertyChangedGeneratorCodeFixProvider.cs" />

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyPropertyChangedGeneratorDiagnosticAnalyzer.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/NotifyPropertyChangedGeneratorDiagnosticAnalyzer.cs
@@ -84,11 +84,12 @@ namespace NotifyPropertyChangedGenerator
                 {
                     return x.Declaration.Variables[0].Identifier.ToString();
                 }
-            }).Distinct().ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
+            }).Select(x => x.TrimStart('_').TrimEnd('_'))
+            .Distinct().ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
 
             foreach (var item in notifyProperties)
             {
-                if (!idInRegion.ContainsKey(item.Identifier.ToString())) goto REPORT_DIAGNOSTIC;
+                if (!idInRegion.ContainsKey(item.Syntax.Identifier.ToString())) goto REPORT_DIAGNOSTIC;
             }
 
             return; // OK

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/Property.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/Property.cs
@@ -37,8 +37,9 @@ namespace NotifyPropertyChangedGenerator
             if (a == null) return NamingConvention.Plain;
 
             var s = a.ToString();
-            return s.Contains("LeadingUnderscore") ? NamingConvention.LeadingUnderscore :
-                s.Contains("TrailingUnderscore") ? NamingConvention.TrailingUnderscore :
+            return
+                s.Contains(nameof(NamingConvention.LeadingUnderscore)) ? NamingConvention.LeadingUnderscore :
+                s.Contains(nameof(NamingConvention.TrailingUnderscore)) ? NamingConvention.TrailingUnderscore :
                 NamingConvention.Plain;
         }
 

--- a/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/Property.cs
+++ b/NotifyPropertyChangedGenerator/NotifyPropertyChangedGenerator/Property.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace NotifyPropertyChangedGenerator
+{
+    internal class Property
+    {
+        public PropertyDeclarationSyntax Syntax { get; }
+
+        public string PropertyName => propertyName ?? (propertyName = Syntax.Identifier.ToString());
+        private string propertyName;
+
+        public string FieldName => fieldName ?? (fieldName = GetFieldName());
+        private string fieldName;
+
+        private string GetFieldName()
+        {
+            var propName = PropertyName;
+            var fieldName = Char.ToLower(propName[0]) + propName.Substring(1);
+
+            switch (NamingConvention)
+            {
+                default:
+                case NamingConvention.Plain: return fieldName;
+                case NamingConvention.LeadingUnderscore: return "_" + fieldName;
+                case NamingConvention.TrailingUnderscore: return fieldName + "_";
+            }
+        }
+
+        public NamingConvention NamingConvention => namingConvension ?? (namingConvension = GetNamingConvention()).Value;
+
+        private NamingConvention? namingConvension;
+
+        private NamingConvention GetNamingConvention()
+        {
+            var a = PropertyAttribute ?? ClassAttribute;
+            if (a == null) return NamingConvention.Plain;
+
+            var s = a.ToString();
+            return s.Contains("LeadingUnderscore") ? NamingConvention.LeadingUnderscore :
+                s.Contains("TrailingUnderscore") ? NamingConvention.TrailingUnderscore :
+                NamingConvention.Plain;
+        }
+
+        private AttributeSyntax PropertyAttribute => propertyAttribute ?? (propertyAttribute = Syntax.GetNotifyAttribute());
+        private AttributeSyntax propertyAttribute;
+
+        private AttributeSyntax ClassAttribute { get; }
+
+        public Property(PropertyDeclarationSyntax syntax, AttributeSyntax attribute = null, AttributeSyntax classAttribute = null)
+        {
+            Syntax = syntax;
+            propertyAttribute = attribute;
+            ClassAttribute = classAttribute;
+        }
+    }
+}


### PR DESCRIPTION
- Support some options
  - naming convention: x, _x, or x_
  - compare method: no comparition, `EqualityComparer<T>.Default.Equals`, or `object.ReferenceEquals`
- Add annotation library
